### PR TITLE
pr preview with GitHub pages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,0 @@
-
-
-
----
-branch will be deployed to https://prachtsaal-berlin-(branch name).surge.sh

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -3,47 +3,36 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
+      - 39-pr-preview-with-github-pages
+  workflow_dispatch:  # allows manual trigger
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+concurrency: ci-${{ github.ref }}
 
 jobs:
-  build:
-    name: Build website
+  deploy:
+    name: Build and deploy website
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.5' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
-      - name: Build static site
-        run: bundle exec jekyll build
-      - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
 
-  deploy:
-    name: Deploy website
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Build static site # creates website in folder _site
+        run: bundle exec jekyll build
+
+      - name: Deploy website
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: _site
+          branch: gh-pages
+          clean-exclude: pr-preview  # used for preview of PRs
+          force: false

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - 39-pr-preview-with-github-pages
   workflow_dispatch:  # allows manual trigger
 
 permissions:

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,26 +1,36 @@
 name: Deploy PR CI
 on:
   pull_request
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  release:
-    name: Deploy website
+  deploy-preview:
+    name: Deploy website PR review
+    concurrency: preview-${{ github.ref }}
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]') && (contains(github.event.comment.body, 'Deploy') || contains(github.event.comment.body, 'deploy') || github.event_name == 'push' || github.event_name == 'pull_request')"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.5'
           bundler-cache: true
+
       - name: Build static site
         run: bundle exec jekyll build
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
         with:
-          node-version: 18
-      - name: Install surge
-        run: npm install -g surge
-      - name: Deploy
-        run: surge _site/ ${{ vars.SURGE_PREFIX }}-${{ github.head_ref }}.${{ vars.SURGE_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }} 
+          source-dir: _site
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,6 +1,6 @@
 name: Deploy PR CI
 on:
-  pull_request
+  pull_request:
     types:
       - opened
       - reopened


### PR DESCRIPTION
Instead of using a third party service like surge, preview pages from a PR on hidden pages in github pages.