### PR TITLE
fix image for art market. also make 48hrNK event visible

### DIFF
--- a/events/_posts/2024-06-30-prachtsaal-in-48-hours-neukolln.md
+++ b/events/_posts/2024-06-30-prachtsaal-in-48-hours-neukolln.md
@@ -10,6 +10,7 @@ images:
     label: 
   - file: /assets/img/events/neon-gods/2024-48hoursNK-group-shot.png
     label: 
+tags: exhibition portfolio
 ---
 
 The Neon Gods They Made, is a fragment of

--- a/events/_posts/2024-09-22-art-market.md
+++ b/events/_posts/2024-09-22-art-market.md
@@ -2,7 +2,7 @@
 layout: event
 title: The Art Market
 subtitle: by Artist Stop Being Poor
-main_image: /assets/img/events/2024-art-market/The-Art-Market-3-posters-04-crop.jpg
+main_image: /assets/img/events/2024-art-market/The-Art-Market-3-posters-04-crop.webp
 description: 
 start_date: 2024-09-20
 images: 


### PR DESCRIPTION
art market page needed new image file extension.

added tags to 48hrsnk event, so that it shows in portfolio.