### PR TITLE
change field name of location of images in entry

### DIFF
--- a/_events/2025-02-16-tape-art-sessions-for-kids.md
+++ b/_events/2025-02-16-tape-art-sessions-for-kids.md
@@ -12,7 +12,7 @@ date: 2025-02-16
 end_date: 2025-03-16
 main_image: /assets/img/events/2025-02-16-tape-art-sessions-for-kids/tape_art_sessions_for_kids_1.jpg
 images:
-  - image: /assets/img/events/2025-02-16-tape-art-sessions-for-kids/tape_art_sessions_for_kids_2.jpg
+  - file: /assets/img/events/2025-02-16-tape-art-sessions-for-kids/tape_art_sessions_for_kids_2.jpg
     caption: Close up of various coloured tapes
 tags: news
 ---

--- a/_events/2025-02-16-tape-art-sessions.md
+++ b/_events/2025-02-16-tape-art-sessions.md
@@ -9,9 +9,9 @@ date: 2025-02-16
 end_date: 2025-03-16
 main_image: /assets/img/events/2025-02-16-tape-art-sessions/tape_art_sessions_1.jpg
 images:
-  - image: /assets/img/events/2025-02-16-tape-art-sessions/tape_art_sessions_2.jpg
+  - file: /assets/img/events/2025-02-16-tape-art-sessions/tape_art_sessions_2.jpg
     caption: Close up of various coloured tapes
-  - image: /assets/img/events/2025-02-16-tape-art-sessions/tape_art_sessions_3.jpg
+  - file: /assets/img/events/2025-02-16-tape-art-sessions/tape_art_sessions_3.jpg
     caption: Proud participants displaying their tape art creations
 tags: news
 ---

--- a/_layouts/entry.html
+++ b/_layouts/entry.html
@@ -36,7 +36,7 @@ layout: default
             {% if page.images%}
             <div class="grid grid-flow-row sm:grid-cols-2 lg:grid-cols-3 justify-center gap-2">
                 {% for img in page.images %}
-                    {% include figure.html src=img.image title=img.caption %}
+                    {% include figure.html src=img.file title=img.caption %}
                 {% endfor %}
             </div>
             {% endif %}


### PR DESCRIPTION
recently the layout for event, now named entry, was changed to accept image file location with the field `image`; before it was `file`. Rather than update all previous events and the readme to this change, I've just changed the most recent files that use the field `image`, and the layout to accept `file`. This is to easily fix the broken images. If it is wished to change the field back to `image`, that is fine, but that can be done in another pull request.