### PR TITLE
end_date default nil

### DIFF
--- a/_layouts/entry.html
+++ b/_layouts/entry.html
@@ -5,7 +5,7 @@ layout: default
 {% if page.end_date %}
 {% capture end_date %} {{page.end_date | date: "%d.%m.%Y"}}{% endcapture %}
 {% else %}
-{% assign end_date = 0 %}
+{% assign end_date = nil %}
 {% endif %}
 
 

--- a/events.html
+++ b/events.html
@@ -20,7 +20,7 @@ add-js: future_events.js
         {% if event.end_date %}
             {% capture end_date %} {{event.end_date | date: "%d.%m.%Y"}}{% endcapture %}
         {% else %}
-            {% assign end_date = 0 %}
+            {% assign end_date = nil %}
         {% endif %}
 
         {% if end_date and end_date != date %}


### PR DESCRIPTION
fixes last pr - default value of 0 is still truthy. in liquid, only `nil` and `false` are falsy.